### PR TITLE
fix for issue #3 assembly error in equate

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1163,7 +1163,7 @@ MNEMONIC *parse(char *buf)
 #endif
 
     Av[0] = Avbuf + j;
-    while (buf[i] && buf[i] != ' ') {
+    while (buf[i] && buf[i] != ' ' && buf[i] != '=') {
 
         if (buf[i] == ':') {
             i++;
@@ -1194,7 +1194,10 @@ MNEMONIC *parse(char *buf)
         while (buf[i] == ' ')
             ++i;
         Av[1] = Avbuf + j;
-        while (buf[i] && buf[i] != ' ') {
+        if (buf[i] == '=') {
+            /* '=' directly seperates Av[0] and Av[2] */
+            Avbuf[j++] = buf[i++];
+        } else while (buf[i] && buf[i] != ' ') {
             if ((unsigned char)buf[i] == 0x80)
                 buf[i] = ' ';
             Avbuf[j++] = buf[i++];

--- a/test/example.asm
+++ b/test/example.asm
@@ -4,6 +4,12 @@
 
 	    processor	6502
 
+; no spaces should be required before or after '=' char
+LABEL1 = 1		
+LABEL2= 2
+LABEL3 =3
+LABEL4=4
+
 	    mac     ldax
 	    lda     [{1}]
 	    ldx     [{1}]+1


### PR DESCRIPTION
Hi Andrew, I fixed the bug you reported, where the following will not assemble:
`LABEL =10` or 
`LABEL= 10` or 
`LABEL=10`

As you reported the bug, could you do a quick code review? And then merge this pull request when you think it's okay?
Another reason to do this pull request is because I want to experience how this works within a GitHub project, and what the process flow is like.

Thanks,
Dion