### PR TITLE
Fix "VERTICAL_SYNC" comment in "atari2600/macro.h"

### DIFF
--- a/machines/atari2600/macro.h
+++ b/machines/atari2600/macro.h
@@ -18,7 +18,7 @@ VERSION_MACRO         = 106
 ;
 ; Latest Revisions...
 ;
-; 1.06  03/SEP/2004     - nice revision of VERTICAL_BLANK (Edwin Blink)
+; 1.06  03/SEP/2004     - nice revision of VERTICAL_SYNC (Edwin Blink)
 ; 1.05  14/NOV/2003     - Added VERSION_MACRO equate (which will reflect 100x version #)
 ;                         This will allow conditional code to verify MACRO.H being
 ;                         used for code assembly.


### PR DESCRIPTION
The file "machines/atari2600/macro.h" contains a reference to a non existing `VERTICAL_BLANK` macro in the "Latest revisions..." comment section. I think it refers to the `VERTICAL_SYNC` macro.

This PR fixes this ref.