### PR TITLE
Fixed misspellings across docs + a header file

### DIFF
--- a/docs/dasm.txt
+++ b/docs/dasm.txt
@@ -174,7 +174,7 @@ VERBOSE OPTIONS:
 	    R1,R2 reason code: R3
 	    where R1 is the number of times the assembler encountered
 	    something requiring another pass to resolve.  R2 is the
-	    number of references to unknown symbols which occured in the
+	    number of references to unknown symbols which occurred in the
 	    pass (but only R1 determines the need for another pass).  R3
 	    is a BITMASK of the reasons why another pass is required.
 	    See the end of this document for bit designations.
@@ -436,7 +436,7 @@ symbol	EQM	    exp
 	    The STRING representing the expression is assigned to the
 	    symbol.  Occurances of the label in later expressions causes
 	    the string to be evaluated for each occurance.  Also used in
-	    conjuction with the DV psuedo-op.
+	    conjunction with the DV psuedo-op.
 
 symbol	SET	    exp
 
@@ -467,7 +467,7 @@ symbol	SETSTR	    exp
 
 	MEXIT
 
-	    Used in conjuction with conditionals.  Exits the current macro
+	    Used in conjunction with conditionals.  Exits the current macro
 	    level.
 
 [label] IFCONST     exp

--- a/docs/sources/changelog.tex
+++ b/docs/sources/changelog.tex
@@ -16,7 +16,7 @@ This section lists recent changes to the document, with most recent entries firs
 
 \item[]\mono{2020.09.13}
 \item Added some structure (new chapters) to the document for inclusion of information about the "other" processors and machines. Started to separate the machine from the processor into separate sections. Should we do an all-in listing of opcodes for all processors, like for the 6502?
-\item Removed malformed coments examples as they are no longer applicable
+\item Removed malformed comments examples as they are no longer applicable
 \item \hyperref[changelog:20200913bugs]{Added link to bugs/issue reporting}
 
 \item[]\mono{2020.09.09}
@@ -32,7 +32,7 @@ This section lists recent changes to the document, with most recent entries firs
 \item \hyperref[changelog:20200908atari]{Fixed some errors in the Atari 2600 section. Switched to SI standard units for describing powers of 2 sizes. I suspect people may not like that!}
 
 \item[]\mono{2020.09.07}
-\item \hyperref[changelog:20200907deprecated]{Added the really unusal (and deprecated) definition for labels... "\mono{[ ]...\textasciicircum[ ]...label}". This is a suppored/valid format, but it is likely to be removed. Do not use.}
+\item \hyperref[changelog:20200907deprecated]{Added the really unusal (and deprecated) definition for labels... "\mono{[ ]...\textasciicircum[ ]...label}". This is a supported/valid format, but it is likely to be removed. Do not use.}
 
 \item[]\mono{2020.09.06}
 \item \hyperref[changelog:20200906res]{Added the RES directive for the F8 processor. Replaces DS on that architecture.}
@@ -42,7 +42,7 @@ This section lists recent changes to the document, with most recent entries firs
 \item \hyperref[changelog:20200905range]{Documented the range checking of byte and word values.}
 \item \hyperref[changelog:20200904illegal]{Much work on the illegal opcodes section of the 6502 chapter. In particular, all of the mnemonics and opcodes are now checked/cross-referenced with online sources identifying illegal, but functional opcodes. These have been checked against the \dasm source code to find out which are actually used/available. The tables section includes opcode-to-mnemonic, and also cycle timings for all instructions. The missing opcodes that \dasm doesn't support have been identified. The next step of all this will be to list the illegal opcodes that are supported and exactly what they do.}
 \item[]\mono{2020.09.03}
-\item \hyperref[changelog:20200903bug]{Added the information about the broken opcodes in HD6303, retrieved from the file BUGS in the source code. I'm starting to go throught the code itself to bring the manual up to date.}
+\item \hyperref[changelog:20200903bug]{Added the information about the broken opcodes in HD6303, retrieved from the file BUGS in the source code. I'm starting to go through the code itself to bring the manual up to date.}
 \item[]\mono{2020.09.02}
 \item \hyperref[changelog20200901_nop3]{There's a new chapter where all the special-case stuff for specific processors is going. In particular, explicit support of 6502 illegal opcodes is in the process of being documented. Did you even know \dasm explicitly supports many (but not all) of the illegal opcodes and their addressing modes? I knew about explicit support for ``nop 0'' and ``lax'' but few of the others. Note in this section how I have lifted a table from an online page, but have attributed it as I was taught when I was doing my formal research writing, so hopefully this will be OK.}
 \item \hyperref[changelog20200901_nop3]{There's a new chapter with details for each of the machines that are explicitly supported with include files, macros, etc. Of course, I only know the '2600 so that's all there is at this stage. Help needed for the others.}
@@ -57,7 +57,7 @@ This section lists recent changes to the document, with most recent entries firs
 \item[]\mono{2020.08.24}
 \item \hyperref[changelog:20200824const]{Removed 0x for hexadecimal. Apparently recently removed from the code?}
 \item \hyperref[changelog:20200824license]{Upgraded license to GPL v3 to be compatible with .STY files used for generation of this manual} \textbf{NOTE: This change has been reversed/invalidated by use of a new .STY file compatible with GPLv2}
-\item \hyperref[changelog:20200824processor]{Fixed table of processor types to explicity list PROCESSOR values}
+\item \hyperref[changelog:20200824processor]{Fixed table of processor types to explicitly list PROCESSOR values}
 \item \hyperref[changelog:20200824rangebug]{Documented dasm bug in constants signed range checking for 8-bit operands}
 \item \hyperref[changelog:20200824const]{Constants and Numbers duplicate sections merged.}
 \item \hyperref[changelog:20200824arithmetic]{Corrected error in table - || is logical-OR and \&\& is logical-AND when used in expressions. They will return 0 or 1 results.}

--- a/docs/sources/manual.tex
+++ b/docs/sources/manual.tex
@@ -453,7 +453,7 @@ Sets the maximum number of passes performed by \dasm to \mono{value}.
 \dasm will keep performing passes until all references are resolved, or until the maximum number of passes is reached (in which case it will exit with an unresolved symbol error). Typically on machines these days, \dasm is so fast that a high number of passes is acceptable.
 
 \label{changelog:20200824passes}
-The default number of pases is 3.
+The default number of passes is 3.
 
 See \nameref{flag:passes2}.\\
 
@@ -605,7 +605,7 @@ The \mono{-v} option controls the amount of information output by \dasm while it
 &R1,R2 reason code: R3\\
 &where R1 is the number of times the assembler encountered\\
 &something requiring another pass to resolve.  R2 is the\\
-&number of references to unknown symbols which occured in the\\
+&number of references to unknown symbols which occurred in the\\
 &pass (but only R1 determines the need for another pass).  R3\\
 &is a BITMASK of the reasons why another pass is required.\\
 
@@ -769,7 +769,7 @@ Either bracket type may be used in all situatinos.
 \index{Expressions!Brackets!6502}
 
 Use square brackets \mono{[]} when you are unsure. The reason round brackets \mono{()} cannot be used to
-group expressions is due to a conflict with 6502 assembly language which use them to specifiy indirect memory access (for example, ``\mono{lda (zp),y}'').
+group expressions is due to a conflict with 6502 assembly language which use them to specify indirect memory access (for example, ``\mono{lda (zp),y}'').
 
 It is possible to use round brackets \mono{()} instead of square brackets \mono{[]} in expressions following directives, but not following mnemonics.
 
@@ -1245,7 +1245,7 @@ symbol EQM exp
 The string representing the expression is assigned to the
 symbol.  Occurrences of the label in later expressions causes
 the string to be evaluated for each occurrence.  Also used in
-conjuction with the \nameref{pseudoop:dv} psuedo-op.\\
+conjunction with the \nameref{pseudoop:dv} psuedo-op.\\
 
 \hrule
 \subsection{\texttt{SET}}
@@ -2279,7 +2279,7 @@ Paired with \nameref{pseudoop:mac}.\\
   MEXIT
 \end{usage}
 
-Used in conjuction with conditionals.  Exits the current macro level.
+Used in conjunction with conditionals.  Exits the current macro level.
 
 See \nameref{conditionals}.
 

--- a/docs/sources/preface.tex
+++ b/docs/sources/preface.tex
@@ -11,7 +11,7 @@ This section lists recent changes to the document, with most recent entries firs
 \item[]\mono{2020.08.24}
 \item \hyperref[changelog:20200824const]{Removed 0x for hexadecimal. Apparently recently removed from the code?}
 \item \hyperref[changelog:20200824license]{Upgraded license to GPL v3 to be compatible with .STY files used for generation of this manual}
-\item \hyperref[changelog:20200824processor]{Fixed table of processor types to explicity list PROCESSOR values}
+\item \hyperref[changelog:20200824processor]{Fixed table of processor types to explicitly list PROCESSOR values}
 \item \hyperref[changelog:20200824rangebug]{Documented dasm bug in constants signed range checking for 8-bit operands}
 \item \hyperref[changelog:20200824const]{Constants and Numbers duplicate sections merged.}
 \item \hyperref[changelog:20200824arithmetic]{Corrected error in table - || is logical-OR and \&\& is logical-AND when used in expressions. They will return 0 or 1 results.}

--- a/src/asm.h
+++ b/src/asm.h
@@ -74,7 +74,7 @@ enum FORMAT
         ERROR_FILE_ERROR,                               /* Unable to open file */
         ERROR_NOT_RESOLVABLE,                           /* Source is not resolvable */
         ERROR_TOO_MANY_PASSES,                          /* Too many passes - something wrong */
-        ERROR_NON_ABORT,                                /* one or more non-abort errors occured */
+        ERROR_NON_ABORT,                                /* one or more non-abort errors occurred */
 
         ERROR_SYNTAX_ERROR,                             /*  0 */
         ERROR_EXPRESSION_TABLE_OVERFLOW,                /*  1 */


### PR DESCRIPTION
I noticed a couple of misspellings while going through the docs, so I went ahead and searched for some more and compiled them into this PR.