### PR TITLE
Added netbsd to operating systems lists

### DIFF
--- a/README
+++ b/README
@@ -84,7 +84,7 @@ Compiling
           how to fix them reliably, we welcome your contributions!)
 
     DASM has been built and tested successfully on recent versions of Linux,
-    macOS and Windows.
+    macOS, NetBSD and Windows.
 
     If you have successfully built and tested DASM on a different machine
     or operating system, we would love to hear about it.


### PR DESCRIPTION
DASM compiled without issues on NetBSD. Working on getting it into pkgsrc. 

`netbsd-mini$ ./dasm
DASM 2.20.14.1
Copyright (c) 1988-2020 by the DASM team.
License GPLv2+: GNU GPL version 2 or later (see file LICENSE).
DASM is free software: you are free to change and redistribute it.
There is ABSOLUTELY NO WARRANTY, to the extent permitted by law.

Usage: dasm sourcefile [options]

-f#      output format 1-3 (default 1)
-oname   output file name (else a.out)
-lname   list file name (else none generated)
-Lname   list file, containing all passes
-sname   symbol dump file name (else none generated)
-v#      verboseness 0-4 (default 0)
-d       debug mode (for developers)
-Dsymbol              define symbol, set to 0
-Dsymbol=expression   define symbol, set to expression
-Msymbol=expression   define symbol using EQM (same as -D)
-Idir    search directory for INCLUDE and INCBIN
-p#      maximum number of passes
-P#      maximum number of passes, with fewer checks
-T#      symbol table sorting (default 0 = alphabetical, 1 = address/value)
-E#      error format (default 0 = MS, 1 = Dillon, 2 = GNU)
-S       strict syntax checking
-R       remove binary output-file in case of errors
-m#      safety barrier to abort on recursions, max. allowed file-size in kB

Report bugs on https://github.com/dasm-assembler/dasm please!


Fatal assembly error: Check command-line format.
netbsd-mini$ uname -a
NetBSD netbsd-mini 9.1 NetBSD 9.1 (GENERIC) #0: Sun Oct 18 19:24:30 UTC 2020  mkrepro@mkrepro.NetBSD.org:/usr/src/sys/arch/amd64/compile/GENERIC amd64
netbsd-mini$`