### PR TITLE
added option (-T2) to order symbols by definition appearance in code

### DIFF
--- a/src/asm.h
+++ b/src/asm.h
@@ -39,6 +39,7 @@ typedef enum
   SORTMODE_DEFAULT,
   SORTMODE_ALPHA = SORTMODE_DEFAULT,
   SORTMODE_ADDRESS,
+  SORTMODE_ORDER,
   SORTMODE_MAX
 } sortmode_t;
 
@@ -159,10 +160,10 @@ typedef struct ERRORSTRUCT
 #define IFSTACK     struct _IFSTACK
 #define SEGMENT     struct _SEGMENT
 #define SYMBOL      struct _SYMBOL
-#define STRLIST   	struct _STRLIST
+#define STRLIST     struct _STRLIST
 
 #define DEFORGFILL  255
-#define N_HASH_BITS	12			// 10 was in original implementation
+#define N_HASH_BITS 12          // 10 was in original implementation
 #define SHASHSIZE   (1 << N_HASH_BITS)
 #define MHASHSIZE   (1 << N_HASH_BITS)
 #define SHASHAND    (SHASHSIZE -1)
@@ -171,69 +172,69 @@ typedef struct ERRORSTRUCT
 #define MAXMACLEVEL 32
 #define TAB        9
 
-	/* 
-	 * See the file globals.c for what these correspond to (Cvt[] and Opsize[])
-	 */
-	enum ADDRESS_MODES {
-		AM_IMP,					/*    1 - implied         */
-		AM_IMM8,				/*    2 - immediate 8  bits   */
-		AM_IMM16,				/*    3 - immediate 16 bits   */
-		AM_BYTEADR,				/*    4 - address 8 bits        */
-		AM_BYTEADRX,			/*    5 - index x + 8 bit offset     */
-		AM_BYTEADRY,			/*    6 - index y + 8 bit offset     */
-		AM_WORDADR,				/*    7 - extended addr        */
-		AM_WORDADRX,			/*    8 - index x + 16 bit offset       */
-		AM_WORDADRY,			/*    9 - index y + 16 bit offset      */
-		AM_REL,					/*    10- relative 8 bits   */
-		AM_BYTEREL,			 	/*    11- 8 bits relative    */
-		AM_INDBYTEX,			/*    12- indirect x     */
-		AM_INDBYTEY,			/*    13- indirect y     */
-		AM_INDWORD,				/*    14- indirect immediate    */
-		AM_INDWORDX,			/*    15- indirect 16 bits x-indexed  */
-		AM_INDBYTE,				/*    16- indirect 8 bits        */
-		AM_0X,					/*    17- index x 0 bits        */
-		AM_0Y,					/*    18- index y 0 bits        */
-		AM_BITMOD,				/*    19- spec. bit modifcation     */
-		AM_BITBRAMOD,			/*    20- spec. bit-test rel. branch    */
-		AM_BYTEADR_SP,			/*    21- index SP +8 bits     */
-		AM_WORDADR_SP,			/*    22- index SP +16 bits   */
+    /* 
+     * See the file globals.c for what these correspond to (Cvt[] and Opsize[])
+     */
+    enum ADDRESS_MODES {
+        AM_IMP,                 /*    1 - implied         */
+        AM_IMM8,                /*    2 - immediate 8  bits   */
+        AM_IMM16,               /*    3 - immediate 16 bits   */
+        AM_BYTEADR,             /*    4 - address 8 bits        */
+        AM_BYTEADRX,            /*    5 - index x + 8 bit offset     */
+        AM_BYTEADRY,            /*    6 - index y + 8 bit offset     */
+        AM_WORDADR,             /*    7 - extended addr        */
+        AM_WORDADRX,            /*    8 - index x + 16 bit offset       */
+        AM_WORDADRY,            /*    9 - index y + 16 bit offset      */
+        AM_REL,                 /*    10- relative 8 bits   */
+        AM_BYTEREL,             /*    11- 8 bits relative    */
+        AM_INDBYTEX,            /*    12- indirect x     */
+        AM_INDBYTEY,            /*    13- indirect y     */
+        AM_INDWORD,             /*    14- indirect immediate    */
+        AM_INDWORDX,            /*    15- indirect 16 bits x-indexed  */
+        AM_INDBYTE,             /*    16- indirect 8 bits        */
+        AM_0X,                  /*    17- index x 0 bits        */
+        AM_0Y,                  /*    18- index y 0 bits        */
+        AM_BITMOD,              /*    19- spec. bit modifcation     */
+        AM_BITBRAMOD,           /*    20- spec. bit-test rel. branch    */
+        AM_BYTEADR_SP,          /*    21- index SP +8 bits     */
+        AM_WORDADR_SP,          /*    22- index SP +16 bits   */
 
 
-		AM_SYMBOL,
-		AM_EXPLIST,
-		AM_LONG,
-		AM_BSS,
+        AM_SYMBOL,
+        AM_EXPLIST,
+        AM_LONG,
+        AM_BSS,
 
-		AM_OTHER_ENDIAN,                /* force little endian to DC on big endian machines and the other way round */
+        AM_OTHER_ENDIAN,                /* force little endian to DC on big endian machines and the other way round */
 
-		NUMOC
-	};
+        NUMOC
+    };
 
-#define AF_IMP					( 1L << AM_IMP )
-#define AF_IMM8					( 1L << AM_IMM8 )
-#define AF_IMM16				( 1L << AM_IMM16 )
-#define AF_BYTEADR				( 1L << AM_BYTEADR )
-#define AF_BYTEADRX				( 1L << AM_BYTEADRX )
-#define AF_BYTEADRY				( 1L << AM_BYTEADRY )
-#define AF_WORDADR				( 1L << AM_WORDADR )
-#define AF_WORDADRX				( 1L << AM_WORDADRX )
-#define AF_WORDADRY				( 1L << AM_WORDADRY )
-#define AF_REL					( 1L << AM_REL )
-#define AF_BYTEREL				( 1L << AM_BYTEREL )
-#define AF_INDBYTEX				( 1L << AM_INDBYTEX )
-#define AF_INDBYTEY				( 1L << AM_INDBYTEY )
-#define AF_INDWORD				( 1L << AM_INDWORD )
-#define AF_INDWORDX				( 1L << AM_INDWORDX )
-#define AF_INDBYTE   			( 1L << AM_INDBYTE )
-#define AF_0X					( 1L << AM_0X )
-#define AF_0Y					( 1L << AM_0Y )
-#define AF_BITMOD				( 1L << AM_BITMOD )
-#define AF_BITBRAMOD			( 1L << AM_BITBRAMOD )
-#define AF_BYTEADR_SP			( 1L << AM_BYTEADR_SP )
-#define AF_WORDADR_SP			( 1L << AM_WORDADR_SP )
+#define AF_IMP                  ( 1L << AM_IMP )
+#define AF_IMM8                 ( 1L << AM_IMM8 )
+#define AF_IMM16                ( 1L << AM_IMM16 )
+#define AF_BYTEADR              ( 1L << AM_BYTEADR )
+#define AF_BYTEADRX             ( 1L << AM_BYTEADRX )
+#define AF_BYTEADRY             ( 1L << AM_BYTEADRY )
+#define AF_WORDADR              ( 1L << AM_WORDADR )
+#define AF_WORDADRX             ( 1L << AM_WORDADRX )
+#define AF_WORDADRY             ( 1L << AM_WORDADRY )
+#define AF_REL                  ( 1L << AM_REL )
+#define AF_BYTEREL              ( 1L << AM_BYTEREL )
+#define AF_INDBYTEX             ( 1L << AM_INDBYTEX )
+#define AF_INDBYTEY             ( 1L << AM_INDBYTEY )
+#define AF_INDWORD              ( 1L << AM_INDWORD )
+#define AF_INDWORDX             ( 1L << AM_INDWORDX )
+#define AF_INDBYTE              ( 1L << AM_INDBYTE )
+#define AF_0X                   ( 1L << AM_0X )
+#define AF_0Y                   ( 1L << AM_0Y )
+#define AF_BITMOD               ( 1L << AM_BITMOD )
+#define AF_BITBRAMOD            ( 1L << AM_BITBRAMOD )
+#define AF_BYTEADR_SP           ( 1L << AM_BYTEADR_SP )
+#define AF_WORDADR_SP           ( 1L << AM_WORDADR_SP )
 
-#define AM_BYTE					AM_BYTEADR
-#define AM_WORD					AM_WORDADR
+#define AM_BYTE                 AM_BYTEADR
+#define AM_WORD                 AM_WORDADR
 
 
 
@@ -244,13 +245,13 @@ STRLIST {
 
 #define STRLISTSIZE    sizeof(STRLIST *)
 
-#define MF_BEGM					0x02
-#define MF_IF					0x04
-#define MF_MACRO				0x08
-#define MF_MASK					0x10    /*  has mask argument (byte)    */
-#define MF_REL					0x20    /*  has rel. address (byte)    */
-#define MF_IMOD					0x40    /*  instruction byte mod.    */
-#define MF_ENDM					0x80    /*  is v_endm            */
+#define MF_BEGM                 0x02
+#define MF_IF                   0x04
+#define MF_MACRO                0x08
+#define MF_MASK                 0x10    /*  has mask argument (byte)    */
+#define MF_REL                  0x20    /*  has rel. address (byte)    */
+#define MF_IMOD                 0x40    /*  instruction byte mod.    */
+#define MF_ENDM                 0x80    /*  is v_endm            */
 
 MNEMONIC {
     MNEMONIC     *next;        /*    hash        */
@@ -347,6 +348,7 @@ SYMBOL {
     unsigned char   addrmode;    /*  addressing mode (expressions)   */
     long value; /* current value, never EVER change this to unsigned! */
     unsigned int namelen;    /*  name length             */
+    long order;
 };
 
 extern SYMBOL    *SHash[];
@@ -373,7 +375,7 @@ extern unsigned char    MsbOrder;
 extern unsigned char    Outputformat;
 extern unsigned long    Redo_why;
 
-extern unsigned long	maxFileSize;
+extern unsigned long    maxFileSize;
 
 extern int Redo;
 extern int Redo_eval;
@@ -397,6 +399,7 @@ extern char    ListMode;
 extern unsigned long    Processor;
 
 /*extern unsigned int _fmode;*/
+extern unsigned long  SymbolCount;
 extern unsigned long  CheckSum;
 
 extern int nMacroDeclarations;
@@ -420,9 +423,9 @@ void addmsg(char *message);
 void    setspecial(int value, int flags);
 SYMBOL *allocsymbol(void);
 SYMBOL *findsymbol(const char *str, int len);
-SYMBOL *CreateSymbol( const char *str, int len );
+SYMBOL *CreateSymbol( const char *str, int len, bool addToOrder );
 void    FreeSymbolList(SYMBOL *sym);
-void    programlabel(void);
+void    programlabel();
 
 /* ops.c */
 extern    unsigned char Gen[];

--- a/src/exp.c
+++ b/src/exp.c
@@ -142,20 +142,20 @@ SYMBOL *eval(const char *str, int wantmode)
     int oldargibase = Argibase;
     int oldopibase = Opibase;
     int scr;
-    
+
     const char *pLine = str;
 
     Argibase = Argi;
     Opibase = Opi;
     Lastwasop = 1;
     base = cur = allocsymbol();
-    
+
 
     while (*str)
     {
         if (Xdebug)
             printf("char '%c'\n", *str);
-        
+
         switch(*str)
         {
         case ' ':
@@ -213,7 +213,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '>':   /*  18: >> <<  17: > >= <= <    */
-            
+
             if (Lastwasop)
             {
                 doop((opfunc_t)op_takemsb, 128);
@@ -240,7 +240,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '<':
-            
+
             if (Lastwasop)
             {
                 doop((opfunc_t)op_takelsb, 128);
@@ -266,7 +266,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '=':   /*  16: ==  (= same as ==)      */
-            
+
             if (str[1] == '=')
                 ++str;
             doop((opfunc_t)op_eqeq, 16);
@@ -274,7 +274,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '!':   /*  16: !=                      */
-            
+
             if (Lastwasop)
             {
                 doop((opfunc_t)op_not, 128);
@@ -288,7 +288,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '&':   /*  15: &   12: &&              */
-            
+
             if (str[1] == '&')
             {
                 doop((opfunc_t)op_andand, 12);
@@ -302,13 +302,13 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '^':   /*  14: ^                       */
-            
+
             doop((opfunc_t)op_xor, 14);
             ++str;
             break;
 
         case '|':   /*  13: |   11: ||              */
-            
+
             if (str[1] == '|')
             {
                 doop((opfunc_t)op_oror, 11);
@@ -321,21 +321,21 @@ SYMBOL *eval(const char *str, int wantmode)
             ++str;
             break;
 
-            
+
         case '(':
-            
+
             if (wantmode)
             {
                 cur->addrmode = AM_INDWORD;
                 ++str;
                 break;
             }
-            
+
             /* fall thru OK */
-            
+
         case '[':   /*  eventually an argument      */
 	    ucasm_indexed_notation = false;
-            
+
 	    if ((((((str[1]|0x20) == 'x') || ((str[1]|0x20) == 'y')) && (str[2] == '+')) ||     // X- or Y-indexed address mode
 	        (((str[1]|0x20) == 's') && ((str[2]|0x20) == 'p') && (str[3] == '+'))) &&	// SP-indexed address mode
 		((Processor == 68705) || (Processor == 6811) || (Processor == 68908)))
@@ -343,14 +343,14 @@ SYMBOL *eval(const char *str, int wantmode)
 		ucasm_indexed_notation = true;
 		// UCASM compatibility, allow notations [X+255], [Y+3], [SP+5]
 		switch(str[1]|0x20) {
-		    case 'x': 
-			cur->addrmode = AM_BYTEADRX; 
+		    case 'x':
+			cur->addrmode = AM_BYTEADRX;
 			//FIX: OPCODE.FORCE / Mnext adaption moved to ops.c
 			break;
 
 		    case 'y': cur->addrmode = AM_BYTEADRY; break;
 
-		    case 's': 
+		    case 's':
 			cur->addrmode = AM_BYTEADR_SP;
 			//FIX: OPCODE.FORCE / Mnext adaption moved to ops.c
 			break;
@@ -368,9 +368,9 @@ SYMBOL *eval(const char *str, int wantmode)
             ++str;
 	    }
             break;
-            
+
         case ')':
-            
+
             if (wantmode)
             {
                 if (cur->addrmode == AM_INDWORD && str[1] == ',' && (str[2]|0x20) == 'y')
@@ -399,11 +399,11 @@ SYMBOL *eval(const char *str, int wantmode)
                 ++str;
                 break;
             }
-            
+
             /* fall thru OK */
-            
+
         case ']':
-            
+
             while(Opi != Opibase && Oppri[Opi-1])
                 evaltop();
             if (Opi != Opibase)
@@ -419,7 +419,7 @@ SYMBOL *eval(const char *str, int wantmode)
                 break;
             }
             }
-            
+
             if (*str == 'd')
             {  /*  STRING CONVERSION   */
                 char buf[32];
@@ -434,7 +434,7 @@ SYMBOL *eval(const char *str, int wantmode)
             break;
 
         case '#':
-            
+
             cur->addrmode = AM_IMM8;
             ++str;
             /*
@@ -443,14 +443,14 @@ SYMBOL *eval(const char *str, int wantmode)
             */
             wantmode = 0;
             break;
-            
+
         case ',':
-            
+
             while(Opi != Opibase)
                 evaltop();
             Lastwasop = 1;
             scr = str[1]|0x20;	  /* to lower case */
-            
+
             if (cur->addrmode == AM_INDWORD && scr == 'x' && !IsAlphaNum( str[2] ))
             {
                 cur->addrmode = AM_INDBYTEX;
@@ -488,7 +488,7 @@ SYMBOL *eval(const char *str, int wantmode)
                    //we treat the opcode as valid to allow passes to continue, which should
                    //allow other errors (like phase errros) to resolve before our "++Redo"
                    //ultimately forces a failure.
-                   cur->addrmode = AM_0Y; 
+                   cur->addrmode = AM_0Y;
                    ++str;
 
             }
@@ -522,7 +522,7 @@ SYMBOL *eval(const char *str, int wantmode)
                     asmerr( ERROR_SYNTAX_ERROR, false, pLine );
                 cur->value = Argstack[Argi];
                 cur->flags = Argflags[Argi];
-                
+
                 if ((cur->string = (void *)Argstring[Argi]) != NULL)
                 {
                     cur->flags |= SYM_STRING;
@@ -580,7 +580,7 @@ SYMBOL *eval(const char *str, int wantmode)
 
     while(Opi != Opibase)
         evaltop();
-    
+
     if (Argi != Argibase)
     {
         --Argi;
@@ -622,7 +622,7 @@ void evaltop(void)
 {
     if (Xdebug)
         printf("evaltop @(A,O) %d %d\n", Argi, Opi);
-    
+
     if (Opi <= Opibase) {
         asmerr( ERROR_SYNTAX_ERROR, false, NULL );
         Opi = Opibase;
@@ -662,10 +662,10 @@ void evaltop(void)
 static void stackarg(long val, int flags, const char *ptr1)
 {
     char *str = NULL;
-    
+
     if (Xdebug)
         printf("stackarg %ld (@%d)\n", val, Argi);
-    
+
     Lastwasop = 0;
     if (flags & SYM_STRING)
     {
@@ -704,9 +704,9 @@ void doop(opfunc_t func, int pri)
 {
     if (Xdebug)
         puts("doop");
-    
+
     Lastwasop = 1;
-    
+
     if (Opi == Opibase || pri == 128)
     {
         if (Xdebug)
@@ -722,17 +722,17 @@ void doop(opfunc_t func, int pri)
         ++Opi;
         return;
     }
-    
+
     while (Opi != Opibase && Oppri[Opi-1] && pri <= Oppri[Opi-1])
         evaltop();
-    
+
     if (Xdebug)
         printf("doop @ %d\n", Opi);
-    
+
     Opdis[Opi] = func;
     Oppri[Opi] = pri;
     ++Opi;
-    
+
     if (Opi == MAXOPS)
     {
         puts("doop: too many operators");
@@ -1013,28 +1013,28 @@ const char *pushsymbol(const char *str)
     {
         if (sym->flags & SYM_UNKNOWN)
             ++Redo_eval;
-        
+
         if (sym->flags & SYM_MACRO)
         {
             macro = 1;
             sym = eval(sym->string, 0);
         }
-        
+
         if (sym->flags & SYM_STRING)
             stackarg(0, SYM_STRING, sym->string);
-        
+
         else
             stackarg(sym->value, sym->flags & SYM_UNKNOWN, NULL);
-        
+
         sym->flags |= SYM_REF|SYM_MASREF;
-        
+
         if (macro)
             FreeSymbolList(sym);
     }
     else
     {
         stackarg(0L, SYM_UNKNOWN, NULL);
-        sym = CreateSymbol( str, ptr - str );
+        sym = CreateSymbol( str, ptr - str, false );
         sym->flags = SYM_REF|SYM_MASREF|SYM_UNKNOWN;
         ++Redo_eval;
     }

--- a/src/globals.c
+++ b/src/globals.c
@@ -69,6 +69,7 @@ unsigned long	Redo_if = 0;
 
 char	ListMode = 1;
 unsigned long	CheckSum;	    /*	output data checksum		*/
+unsigned long	SymbolCount;    /*	symbol order counter        */
 
 int F_format = FORMAT_DEFAULT;
 

--- a/src/main.c
+++ b/src/main.c
@@ -282,7 +282,7 @@ static void ShowSymbols( FILE *file, int sortMode )
                  sftos( symArray[ i ]->value, symArray[ i ]->flags ) );
              if ( symArray[ i ]->flags & SYM_STRING )
                  fprintf( file, " \"%s\"", symArray[ i ]->string );                  /* If a string, display actual string */
-				 fprintf( file, " %i", symArray[ i ]->order );
+			 //fprintf( file, " %i", symArray[ i ]->order ); // enable for debugging -T2
              fprintf( file, "\n" );
          }
 

--- a/src/ops.c
+++ b/src/ops.c
@@ -79,7 +79,7 @@ void v_processor(char *str, MNEMONIC *dummy)
     {
         if ( !bCalled )
             addhashtable(Mne6803);
-        
+
         MsbOrder = 1;	    /*	msb,lsb */
         Processor = 6803;
     }
@@ -100,7 +100,7 @@ void v_processor(char *str, MNEMONIC *dummy)
     {
         if ( !bCalled )
             addhashtable(Mne68705);
-        
+
         MsbOrder = 1;	    /*	msb,lsb */
         Processor = 68705;
     }
@@ -109,7 +109,7 @@ void v_processor(char *str, MNEMONIC *dummy)
     {
         if ( !bCalled )
             addhashtable(Mne68HC11);
-        
+
         MsbOrder = 1;	    /*	msb,lsb */
         Processor = 6811;
     }
@@ -159,11 +159,11 @@ void v_mnemonic(char *str, MNEMONIC *mne)
     int     opsize;
     bool	byteRequested;
     char sBuffer[128];
-    
+
     Csegment->flags |= SF_REF;
     programlabel();
     symbase = eval(str, 1);
-    
+
     if ( bTrace )
         printf("PC: %04lx  MNEMONIC: %s  addrmode: %d  ", Csegment->org, mne->name, symbase->addrmode);
 
@@ -176,7 +176,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         }
     }
     sym = symbase;
-    
+
     if (mne->flags & MF_IMOD)
     {
         if (sym->next)
@@ -191,7 +191,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         opsize = 2;
     else
         opsize = (sym->value) ? 1 : 0;
-    
+
     while (badcode(mne,addrmode) && Cvt[addrmode])
         addrmode = Cvt[addrmode];
 
@@ -199,10 +199,10 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         addrmode = AM_INDWORDX;
     else if (mne->opcode[addrmode] == 0x42 && addrmode == AM_INDBYTE && Processor == 16502)
         addrmode = AM_INDWORD;
-    
+
     if ( bTrace )
         printf("mnemask: %08lx adrmode: %d  Cvt[am]: %d   Mnext:%d   value: %ld\n", mne->okmask, addrmode, Cvt[addrmode], Mnext,  sym->value);
-    
+
     if (badcode(mne,addrmode))
     {
         sprintf( sBuffer, "%s %s", mne->name, str );
@@ -213,12 +213,12 @@ void v_mnemonic(char *str, MNEMONIC *mne)
             Redo_why |= REASON_MNEMONIC_NOT_RESOLVED;
         return;
     }
-    
+
 
     if (Mnext >= 0 && Mnext < NUMOC)            /*	Force	*/
     {
         addrmode = Mnext;
-        
+
         //FIX: OPCODE.FORCE needs to be adjusted for x,y,sp indexing...
         switch(sym->addrmode) {
         	case AM_INDBYTEX:
@@ -266,13 +266,13 @@ void v_mnemonic(char *str, MNEMONIC *mne)
             asmerr( ERROR_ILLEGAL_FORCED_ADDRESSING_MODE, false, mne->name );
             FreeSymbolList(symbase);
 
-               //FIX: Cause assembly to fail when an invalid mode is used for an opcode... 
+               //FIX: Cause assembly to fail when an invalid mode is used for an opcode...
                ++Redo;
                Redo_why |= REASON_MNEMONIC_NOT_RESOLVED;
             return;
         }
     }
-    
+
     if ( bTrace )
         printf("final addrmode = %d, opsize:%d Opsize[%d]:%d\n", addrmode, opsize, addrmode, Opsize[addrmode]);
 
@@ -290,7 +290,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
     		}
     		break;
     }
-    
+
     switch(addrmode) {
     	case AM_IMM16:
     	case AM_WORDADR:
@@ -322,7 +322,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         {
             if (sym->flags & SYM_UNKNOWN)
                 break;
-            
+
             //FIX: for negative operands...
             if ( (addrmode == AM_IMM8) && (sym->value <0) )
             {
@@ -372,7 +372,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
     {
         Gen[0] = opcode;
     }
-    
+
     switch(addrmode)
     {
     case AM_BITMOD:
@@ -382,7 +382,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
             asmerr( ERROR_ADDRESS_MUST_BE_LT_100, false, sBuffer );
         }
         Gen[opidx++] = sym->value;
-        
+
         if (!(symbase->flags & SYM_UNKNOWN))
         {
             if (symbase->value > 7)
@@ -391,9 +391,9 @@ void v_mnemonic(char *str, MNEMONIC *mne)
                 Gen[0] += symbase->value << 1;
         }
         break;
-        
+
     case AM_BITBRAMOD:
-        
+
         if (!(symbase->flags & SYM_UNKNOWN))
         {
             if (symbase->value > 7)
@@ -401,9 +401,9 @@ void v_mnemonic(char *str, MNEMONIC *mne)
             else
                 Gen[0] += symbase->value << 1;
         }
-        
+
         sym = symbase->next;
-        
+
         if (!(sym->flags & SYM_UNKNOWN) && sym->value >= 0x100) {
             sprintf( sBuffer, "%s %ld", mne->name, sym->value);
             asmerr( ERROR_ADDRESS_MUST_BE_LT_100, false, sBuffer );
@@ -411,10 +411,10 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         Gen[opidx++] = sym->value;
         sym = sym->next;
         break;
-        
+
     case AM_REL:
         break;
-        
+
     default:
         if (Opsize[addrmode] > 0)
             Gen[opidx++] = sym->value;
@@ -433,7 +433,7 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         sym = sym->next;
         break;
     }
-    
+
     if (mne->flags & MF_MASK)
     {
         if (sym)
@@ -449,14 +449,14 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         {
             asmerr( ERROR_NOT_ENOUGH_ARGS, true, NULL );
         }
-        
+
         ++opidx;
     }
 
     if ((mne->flags & MF_REL) || addrmode == AM_REL || addrmode == AM_BYTEREL)
     {
         ++opidx;		/*  to end of instruction   */
-        
+
         if (!sym)
             asmerr( ERROR_NOT_ENOUGH_ARGS, true, NULL );
         else if (!(sym->flags & SYM_UNKNOWN))
@@ -464,10 +464,10 @@ void v_mnemonic(char *str, MNEMONIC *mne)
             long    pc;
             unsigned char pcf;
             long    dest;
-            
+
             pc = (Csegment->flags & SF_RORG) ? Csegment->rorg : Csegment->org;
             pcf= (Csegment->flags & SF_RORG) ? Csegment->rflags : Csegment->flags;
-            
+
             if ((pcf & (SF_UNKNOWN|2)) == 0)
             {
                 dest = sym->value - pc - opidx;
@@ -475,14 +475,14 @@ void v_mnemonic(char *str, MNEMONIC *mne)
                 if (dest >= 128 || dest < -128)
                 {
                     //FIX: sometimes zero page addressing will first be assumed to be absolute until
-                    //     another pass. ERROR_BRANCH_OUT_OF_RANGE was made non-fatal, but we keep 
+                    //     another pass. ERROR_BRANCH_OUT_OF_RANGE was made non-fatal, but we keep
                     //     pushing for Redo so assembly won't actually be succesfull until the branch
                     //     actually works.
                         sprintf( sBuffer, "%ld", dest );
                         asmerr( ERROR_BRANCH_OUT_OF_RANGE, false, sBuffer );
             		++Redo;
             		Redo_why |= REASON_BRANCH_OUT_OF_RANGE;
-                        sym->flags=sym->flags | SYM_UNKNOWN; 
+                        sym->flags=sym->flags | SYM_UNKNOWN;
                         dest = 0;
                 }
             }
@@ -507,9 +507,9 @@ void v_trace(char *str, MNEMONIC *dummy)
 void v_list(char *str, MNEMONIC *dummy)
 {
     programlabel();
-    
+
     Glen = 0;		/*  Only so outlist() works */
-    
+
     if (strncmp(str, "localoff", 7) == 0 || strncmp(str, "LOCALOFF", 7) == 0)
         pIncfile->flags |=  INF_NOLIST;
     else if (strncmp(str, "localon", 7) == 0 || strncmp(str, "LOCALON", 7) == 0)
@@ -525,14 +525,14 @@ getfilename(char *str)
 {
     if (*str == '\"') {
         char	*buf;
-        
+
         str++;
         buf = ckmalloc(strlen(str)+1);
         strcpy(buf, str);
-        
+
         for (str = buf; *str && *str != '\"'; ++str);
         *str = 0;
-        
+
         return buf;
     }
     return str;
@@ -542,9 +542,9 @@ void
 v_include(char *str, MNEMONIC *dummy)
 {
   SYMBOL *sym;
-  
+
   programlabel();
-  
+
   // only eval the string if it's compliant with symbol naming
   if ((*str<'0')||(*str>'9')) //check could be more comprehensive
     sym = eval(str, 0);
@@ -559,13 +559,13 @@ v_include(char *str, MNEMONIC *dummy)
   {
     char *buf;
     buf = getfilename(str);
-    
+
     pushinclude(buf);
-    
+
     if (buf != str)
       free(buf);
   }
-  
+
   if (sym)
     FreeSymbolList(sym);
 }
@@ -587,7 +587,7 @@ v_incbin(char *str, MNEMONIC *dummy)
         fname = sym->string;
     }
     buf = getfilename(fname);
-    
+
     long skip_bytes = 0;
     if (sym->next) {
         if (sym->next->flags & SYM_UNKNOWN) {
@@ -620,7 +620,7 @@ v_incbin(char *str, MNEMONIC *dummy)
     {
         printf("unable to open %s\n", buf);
     }
-    
+
     if (buf != str)
         free(buf);
     Glen = 0;		    /* don't list hexdump */
@@ -632,7 +632,7 @@ void
 v_seg(char *str, MNEMONIC *dummy)
 {
     SEGMENT *seg;
-    
+
     for (seg = Seglist; seg; seg = seg->next) {
         if (strcmp(str, seg->name) == 0) {
             Csegment = seg;
@@ -655,7 +655,7 @@ v_hex(char *str, MNEMONIC *dummy)
 {
     int i;
     int result;
-    
+
     programlabel();
     Glen = 0;
     for (i = 0; str[i]; ++i) {
@@ -673,23 +673,23 @@ int
 gethexdig(int c)
 {
     char sBuffer[64];
-    
+
     if (c >= '0' && c <= '9')
         return c - '0';
-    
+
     if (c >= 'a' && c <= 'f')
         return c - 'a' + 10;
-    
+
     if (c >= 'A' && c <= 'F')
         return c - 'A' + 10;
-    
+
     sprintf( sBuffer, "Bad Hex Digit %c", c );
     asmerr( ERROR_SYNTAX_ERROR, false, sBuffer );
-    
+
     puts("(Must be a valid hex digit)");
     if (F_listfile)
         fputs("(Must be a valid hex digit)\n", FI_listfile);
-    
+
     return 0;
 }
 
@@ -710,7 +710,7 @@ v_dc(char *str, MNEMONIC *mne)
     char *macstr = 0;		/* "might be used uninitialised" */
     char vmode = 0;
     char sBuffer[128];		/* verbose error messages*/
-    
+
     Glen = 0;
     programlabel();
 
@@ -738,7 +738,7 @@ v_dc(char *str, MNEMONIC *mne)
     }
 
 	/* ...F8 */
-	
+
 
 
     if (mne->name[1] == 'v') {
@@ -842,7 +842,7 @@ v_dc(char *str, MNEMONIC *mne)
             default:
             case AM_BYTE:
                 //any value outside two's complement +ve and +ve byte representation is invalid...
-                if ((value < -0xFF)||(value > 0xFF)) 
+                if ((value < -0xFF)||(value > 0xFF))
 		{
                     sprintf( sBuffer, "byte %s %ld", mne->name, value);
                     asmerr( ERROR_ADDRESS_MUST_BE_LT_100, false, sBuffer );
@@ -912,7 +912,7 @@ v_ds(char *str, MNEMONIC *dummy)
     SYMBOL *sym;
     int mult = 1;
     long filler = 0;
-    
+
     if (Mnext == AM_WORD)
         mult = 2;
     if (Mnext == AM_LONG)
@@ -941,28 +941,28 @@ void
 v_org(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym;
-    
+
     sym = eval(str, 0);
     Csegment->org = sym->value;
-    
+
     if (sym->flags & SYM_UNKNOWN)
         Csegment->flags |= SYM_UNKNOWN;
     else
         Csegment->flags &= ~SYM_UNKNOWN;
-    
+
     if (Csegment->initflags & SYM_UNKNOWN)
     {
         Csegment->initorg = sym->value;
         Csegment->initflags = sym->flags;
     }
-    
+
     if (sym->next)
     {
         OrgFill = sym->next->value;
         if (sym->next->flags & SYM_UNKNOWN)
             asmerr( ERROR_VALUE_UNDEFINED, true, NULL );
     }
-    
+
     programlabel();
     FreeSymbolList(sym);
 }
@@ -971,7 +971,7 @@ void
 v_rorg(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym = eval(str, 0);
-    
+
     Csegment->flags |= SF_RORG;
     if (sym->addrmode != AM_IMP) {
         Csegment->rorg = sym->value;
@@ -1001,7 +1001,7 @@ v_align(char *str, MNEMONIC *dummy)
     SYMBOL *sym = eval(str, 0);
     unsigned char fill = 0;
     unsigned char rorg = Csegment->flags & SF_RORG;
-    
+
     if (rorg)
         Csegment->rflags |= SF_REF;
     else
@@ -1058,8 +1058,8 @@ v_equ(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym = eval(str, 0);
     SYMBOL *lab;
-    
-    
+
+
     /*
     * If we encounter a line of the form
     *   . = expr	; or . EQU expr
@@ -1082,11 +1082,11 @@ v_equ(char *str, MNEMONIC *dummy)
         }
         return;
     }
-    
-    
+
+
     lab = findsymbol(Av[0], strlen(Av[0]));
     if (!lab)
-        lab = CreateSymbol( Av[0], strlen(Av[0]) );
+        lab = CreateSymbol( Av[0], strlen(Av[0]), true );
     if (!(lab->flags & SYM_UNKNOWN))
     {
         if (sym->flags & SYM_UNKNOWN)
@@ -1106,16 +1106,16 @@ v_equ(char *str, MNEMONIC *dummy)
             }
         }
     }
-    
+
     lab->value = sym->value;
     lab->flags = sym->flags & (SYM_UNKNOWN|SYM_STRING);
     lab->string = sym->string;
     sym->flags &= ~(SYM_STRING|SYM_MACRO);
-    
+
     /* List the value */
     {
         unsigned long v = lab->value;
-        
+
         Glen = 0;
         if (v > 0x0000FFFF)
         {
@@ -1125,8 +1125,8 @@ v_equ(char *str, MNEMONIC *dummy)
         Gen[Glen++] = v >>  8;
         Gen[Glen++] = v;
     }
-    
-    
+
+
     FreeSymbolList(sym);
 }
 
@@ -1135,14 +1135,14 @@ v_eqm(char *str, MNEMONIC *dummy)
 {
     SYMBOL *lab;
     int len = strlen(Av[0]);
-    
+
     if ((lab = findsymbol(Av[0], len)) != NULL) {
         if (lab->flags & SYM_STRING)
             free(lab->string);
     }
     else
     {
-        lab = CreateSymbol( Av[0], len );
+        lab = CreateSymbol( Av[0], len, true );
     }
     lab->value = 0;
     lab->flags = SYM_STRING | SYM_SET | SYM_MACRO;
@@ -1155,7 +1155,7 @@ v_echo(char *str, MNEMONIC *dummy)
     SYMBOL *sym = eval(str, 0);
     SYMBOL *s;
     char buf[256];
-    
+
     for (s = sym; s; s = s->next) {
         if (!(s->flags & SYM_UNKNOWN)) {
             if (s->flags & (SYM_MACRO|SYM_STRING))
@@ -1164,7 +1164,7 @@ v_echo(char *str, MNEMONIC *dummy)
                 sprintf(buf,"$%lx", s->value);
             if (FI_listfile)
                 fprintf(FI_listfile, " %s", buf);
-            //printf(" %s", buf); 
+            //printf(" %s", buf);
             addmsg(" "); // -FXQ supress output until final pass
             addmsg(buf);
         }
@@ -1201,7 +1201,7 @@ void v_set(char *str, MNEMONIC *dummy)
             {
                 break;
             }
-            if(str[i+1]=='"') // is this a string constant? 
+            if(str[i+1]=='"') // is this a string constant?
             {
                 i=i+2; // advance to string contents
                 while (str[i] && str[i] != '"' && str[i] != ' ' && str[i] != ',')
@@ -1264,7 +1264,7 @@ void v_set(char *str, MNEMONIC *dummy)
 
     lab = findsymbol(Av[0], strlen(Av[0]));
     if (!lab)
-        lab = CreateSymbol( Av[0], strlen(Av[0]) );
+        lab = CreateSymbol( Av[0], strlen(Av[0]), true );
     lab->value = sym->value;
     lab->flags = sym->flags & (SYM_UNKNOWN|SYM_STRING);
     lab->string = sym->string;
@@ -1286,9 +1286,9 @@ v_execmac(char *str, MACRO *mac)
     STRLIST *base;
     STRLIST **psl, *sl;
     char *s1;
-    
+
     programlabel();
-    
+
     if (Mlevel == MAXMACLEVEL) {
         char errMsg[256];
         sprintf(errMsg, " macro [%s] recursion > %d", mac->name, MAXMACLEVEL);
@@ -1315,7 +1315,7 @@ v_execmac(char *str, MACRO *mac)
         while (*str == ' ')
             ++str;
     }
-    
+
     inc = (INCFILE *)zmalloc(sizeof(INCFILE));
     inc->next = pIncfile;
     inc->name = mac->name;
@@ -1323,28 +1323,28 @@ v_execmac(char *str, MACRO *mac)
     inc->lineno = 0;
     inc->flags = INF_MACRO;
     inc->saveidx = Localindex;
-    
+
     inc->savedolidx = Localdollarindex;
-    
+
     inc->strlist = mac->strlist;
     inc->args	  = base;
     pIncfile = inc;
-    
+
     ++Lastlocalindex;
     Localindex = Lastlocalindex;
-    
+
     ++Lastlocaldollarindex;
     Localdollarindex = Lastlocaldollarindex;
-    
+
 }
 
 void v_end(char *str, MNEMONIC *dummy)
 {
     /* Only ENDs current file and any macro calls within it */
-    
+
     while ( pIncfile->flags & INF_MACRO)
         v_endm(NULL, NULL);
-    
+
     fseek( pIncfile->fi, 0, SEEK_END);
 }
 
@@ -1353,7 +1353,7 @@ v_endm(char *str, MNEMONIC *dummy)
 {
     INCFILE *inc = pIncfile;
     STRLIST *args, *an;
-    
+
     /* programlabel(); contrary to documentation */
     if (inc->flags & INF_MACRO) {
         --Mlevel;
@@ -1362,9 +1362,9 @@ v_endm(char *str, MNEMONIC *dummy)
             free(args);
         }
         Localindex = inc->saveidx;
-        
+
         Localdollarindex = inc->savedolidx;
-        
+
         pIncfile = inc->next;
         free(inc);
         return;
@@ -1382,7 +1382,7 @@ void
 v_ifconst(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym;
-    
+
     programlabel();
     sym = eval(str, 0);
     pushif(sym->flags == 0);
@@ -1393,7 +1393,7 @@ void
 v_ifnconst(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym;
-    
+
     programlabel();
     sym = eval(str, 0);
     pushif(sym->flags != 0);
@@ -1404,7 +1404,7 @@ void
 v_if(char *str, MNEMONIC *dummy)
 {
     SYMBOL *sym;
-    
+
     if (!Ifstack->xtrue || !Ifstack->acctrue) {
         pushif(0);
         return;
@@ -1416,9 +1416,9 @@ v_if(char *str, MNEMONIC *dummy)
         Redo_why |= REASON_IF_NOT_RESOLVED;
         pushif(0);
         Ifstack->acctrue = 0;
-        
+
         Redo_if |= 1;
-        
+
     }
     else
     {
@@ -1439,7 +1439,7 @@ void
 v_endif(char *str, MNEMONIC *dummy)
 {
     IFSTACK *ifs = Ifstack;
-    
+
     if (!(ifs->flags & IFF_BASE)) {
         if (ifs->acctrue)
             programlabel();
@@ -1458,7 +1458,7 @@ void v_repeat(char *str, MNEMONIC *dummy)
 {
     REPLOOP *rp;
     SYMBOL *sym;
-    
+
     if (!Ifstack->xtrue || !Ifstack->acctrue) {
         pushif(0);
         return;
@@ -1470,22 +1470,22 @@ void v_repeat(char *str, MNEMONIC *dummy)
         FreeSymbolList(sym);
         return;
     }
-    
+
 #ifdef DAD
-    
+
     /* Don't allow negative values for REPEAT loops */
-    
+
     if ( sym->value < 0 )
     {
         pushif( 0 );
         FreeSymbolList( sym );
-        
+
         asmerr( ERROR_REPEAT_NEGATIVE, false, NULL );
         return;
     }
-    
+
 #endif
-    
+
     rp = (REPLOOP *)zmalloc(sizeof(REPLOOP));
     rp->next = Reploop;
     rp->file = pIncfile;
@@ -1539,22 +1539,22 @@ v_incdir(char *str, MNEMONIC *dummy)
     STRLIST **tail;
     char *buf;
     int found = 0;
-    
+
     buf = getfilename(str);
-    
+
     for (tail = &incdirlist; *tail; tail = &(*tail)->next) {
         if (strcmp((*tail)->buf, buf) == 0)
             found = 1;
     }
-    
+
     if (!found) {
         STRLIST *newdir;
-        
+
         newdir = (STRLIST *)permalloc(STRLISTSIZE + 1 + strlen(buf));
         strcpy(newdir->buf, buf);
         *tail = newdir;
     }
-    
+
     if (buf != str)
         free(buf);
 }
@@ -1570,7 +1570,7 @@ addpart(char *dest, const char *dir, const char *file)
 #endif
     {
         int pos;
-        
+
         strcpy(dest, dir);
         pos = strlen(dest);
         if (pos > 0 && dest[pos-1] != ':' && dest[pos-1] != '/') {
@@ -1587,25 +1587,25 @@ pfopen(const char *name, const char *mode)
     FILE *f;
     STRLIST *incdir;
     char *buf;
-    
+
     f = fopen(name, mode);
     if (f)
         return f;
-    
+
     /* Don't use the incdirlist for absolute pathnames */
     if (strchr(name, ':'))
         return NULL;
-    
+
     buf = zmalloc(512);
-    
+
     for (incdir = incdirlist; incdir; incdir = incdir->next) {
         addpart(buf, incdir->buf, name);
-        
+
         f = fopen(buf, mode);
         if (f)
             break;
     }
-    
+
     free(buf);
     return f;
 }
@@ -1620,14 +1620,14 @@ generate(void)
     long seekpos;
     static unsigned long org;
     int i;
-    
+
     if (!Redo)
     {
         if (!(Csegment->flags & SF_BSS))
         {
             for (i = Glen - 1; i >= 0; --i)
                 CheckSum += Gen[i];
-            
+
             if (Fisclear)
             {
                 Fisclear = 0;
@@ -1637,14 +1637,14 @@ generate(void)
                     Redo_why |= REASON_OBSCURE;
                     return;
                 }
-                
+
                 org = Csegment->org;
-                
+
                 if ( F_format < FORMAT_RAW )
                 {
                     putc((org & 0xFF), FI_temp);
                     putc(((org >> 8) & 0xFF), FI_temp);
-                    
+
                     if ( F_format == FORMAT_RAS )
                     {
                         Seekback = ftell(FI_temp);
@@ -1654,10 +1654,10 @@ generate(void)
                     }
                 }
             }
-            
+
             switch(F_format)
             {
-            
+
             default:
 
                 asmerr( ERROR_BAD_FORMAT, true, "Unhandled internal format specifier" );
@@ -1665,7 +1665,7 @@ generate(void)
 
             case FORMAT_RAW:
             case FORMAT_DEFAULT:
-                
+
                 if (Csegment->org < org)
                 {
                     printf("segment: %s %s  vs current org: %04lx\n",
@@ -1673,18 +1673,18 @@ generate(void)
                     asmerr( ERROR_ORIGIN_REVERSE_INDEXED, true, NULL );
                     exit(1);
                 }
-                
+
                 while (Csegment->org != org)
                 {
                     putc(OrgFill, FI_temp);
                     ++org;
                 }
-                
+
                 fwrite(Gen, Glen, 1, FI_temp);
                 break;
-                
+
             case FORMAT_RAS:
-                
+
                 if (org != Csegment->org)
                 {
                     org = Csegment->org;
@@ -1700,18 +1700,18 @@ generate(void)
                     putc(0, FI_temp);
                     putc(0, FI_temp);
                 }
-                
+
                 fwrite(Gen, Glen, 1, FI_temp);
                 Seglen += Glen;
                 break;
-            
+
             }
             org += Glen;
         }
     }
-    
+
     Csegment->org += Glen;
-    
+
     if (Csegment->flags & SF_RORG)
         Csegment->rorg += Glen;
 
@@ -1744,7 +1744,7 @@ genfill(long fill, long entries, int size)
     long bytes = entries;  /*	multiplied later    */
     int i;
     unsigned char c3,c2,c1,c0;
-    
+
     if (bytes == 0) {
     	// nothing to do
         return;
@@ -1753,7 +1753,7 @@ genfill(long fill, long entries, int size)
     	asmerr( ERROR_ORIGIN_REVERSE_INDEXED, true, NULL );
     	return;
     }
-    
+
     c3 = fill >> 24;
     c2 = fill >> 16;
     c1 = fill >> 8;
@@ -1763,7 +1763,7 @@ genfill(long fill, long entries, int size)
     case 1:
         memset(Gen, c0, sizeof(Gen));
         break;
-        
+
     case 2:
         bytes <<= 1;
         for (i = 0; i < sizeof(Gen); i += 2)
@@ -1780,7 +1780,7 @@ genfill(long fill, long entries, int size)
             }
         }
         break;
-        
+
     case 4:
         bytes <<= 2;
         for (i = 0; i < sizeof(Gen); i += 4)
@@ -1802,7 +1802,7 @@ genfill(long fill, long entries, int size)
         }
         break;
     }
-    
+
     for (Glen = sizeof(Gen); bytes > sizeof(Gen); bytes -= sizeof(Gen))
         generate();
     Glen = bytes;

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -34,7 +34,7 @@
 
 #include <stdbool.h>
 
-void programlabel(bool addToOrder = true);
+void programlabel();
 void ShowSymbols(FILE *file);
 size_t ShowUnresolvedSymbols(void);
 void DumpSymbolTable(void);

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -34,7 +34,7 @@
 
 #include <stdbool.h>
 
-void programlabel(void);
+void programlabel(bool addToOrder = true);
 void ShowSymbols(FILE *file);
 size_t ShowUnresolvedSymbols(void);
 void DumpSymbolTable(void);
@@ -62,7 +62,7 @@ void set_special_dv_symbol(int value, dasm_flag_t flags);
  * created symbol is SYM_UNKNOWN.
  * @pre str != NULL && len > 0
  */
-SYMBOL *create_symbol(const char *str, size_t len);
+SYMBOL *create_symbol(const char *str, size_t len, bool addToOrder);
 
 /**
  * @brief Find symbol with given name in hash table.
@@ -104,6 +104,7 @@ typedef enum
     /* actual sort modes */
     SORTMODE_ALPHA,
     SORTMODE_ADDRESS,
+    SORTMODE_ORDER,
 
     /* meta data */
     SORTMODE_MIN = SORTMODE_ALPHA,


### PR DESCRIPTION
By ordering the symbol according to their definition order in the code, the disassembling can be significantly improved.

Using their own, well defined symbols, the disassemblers and debuggers can group the symbol file. From that grouping, the type of a symbol can be identified (e.g. constant vs. variable). Also in bankswitched code (e.g. Atari 2600), the disassembler will know to which bank a label belongs.

Now:
```
BLUE = $80
...
var = $80
...
; bank0
LabelFromBank0
  lda BLUE          ; !!!
  lda #BLUE
  ...
; bank1
LabelFromBank0      ; !!!
```
Future:
```
DASM_CONSTS
BLUE = $80
...
DASM_ZP_VARS
var = $80
...
DASM_BANK_0
LabelFromBank0
  lda var           ; !!!
  lda #BLUE
  ...
DASM_BANK_1
LabelFromBank1      ; !!!
```

