### PR TITLE
fix compiler warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,26 +26,50 @@
 # trunk/ Makefile!
 
 
-#GOPTI= -O -m32 # -O for more warnings; use -O0 for debugging, use -O3 for speed
+M32BIT = -m32
 
-GWARN= -ansi -std=c99 -pedantic -Wall \
-       -Wstrict-prototypes -Wdeclaration-after-statement \
-       -Wold-style-definition -Wmissing-declarations -Wmissing-prototypes \
-       -Wshadow -Wwrite-strings -Wcast-qual -Wnested-externs \
-       -Wcast-align -Wpointer-arith -Wbad-function-cast \
-       -Wformat-y2k -Wformat-nonliteral -Wformat-security \
-       -Wfloat-equal -Wundef -Winline \
-       # -Wfour-char-constants # Apple OS X only option, not needed anyway?
-       # -Wunused # definition is weird in man gcc, effect is weird too
-       # -Wextra -Wno-unused-parameter # no-unused tames extra a little
-       # -Wunreachable-code # seems to create 4 spurious warnings?
-       # -Wconversion # too many right now
-       # -Wtraditional # too many, not sure if it's worth it anyway
+#GOPTI = -O -m32 # -O for more warnings; use -O0 for debugging, use -O3 for speed
+GOPTI  = -O2 # -O for more warnings; use -O0 for debugging, use -O3 for speed
+GOPTI += $(M32BIT)
 
-#GDEBG= -g # -fprofile-arcs -ftest-coverage -pg # -D_FORTIFY_SOURCE=2
+#GWARN= -ansi -std=c18 -pedantic -Wall
+GWARN =  -ansi -std=c99 -pedantic -Wall
+GWARN += -Wmissing-declarations
+GWARN += -Wmissing-prototypes
+GWARN += -Wold-style-definition
+GWARN += -Wshadow
+GWARN += -Wcast-qual
+GWARN += -Wnested-externs
+GWARN += -Wunused 	# definition is weird in man gcc, effect is weird too
+GWARN += -Wundef
+GWARN += -Winline
+GWARN += -Wfloat-equal
+GWARN += -Wunreachable-code # seems to create 4 spurious warnings?
+GWARN += -Wno-unused-parameter # no-unused tames extra a little
+GWARN += -Wformat-y2k
+GWARN += -Wformat-security
+GWARN += -Wcast-align
+GWARN += -Wpointer-arith
+GWARN += -Wbad-function-cast
+GWARN += -Wmisleading-indentation
+#GWARN += -Wstrict-prototypes
+#GWARN += -Wdeclaration-after-statement
+#GWARN += -Wwrite-strings
+#GWARN += -Wconversion # too many right now
+#GWARN += -Wtraditional # too many, not sure if it's worth it anyway
+#GWARN += -Wextra
+#GWARN += -Wformat-nonliteral
+#GWARN += -Wfour-char-constants # Apple OS X only option, not needed anyway?
 
-#CFLAGS= $(GOPTI) $(GWARN) $(GDEBG)
-#LDFLAGS= -m32 -L/usr/lib32
+GDEBG  = -g # -fprofile-arcs -ftest-coverage -pg # -D_FORTIFY_SOURCE=2
+#GDEBG += -fprofile-arcs
+GDEBG += -ftest-coverage
+#GDEBG += -pg
+#GDEBG += -D_FORTIFY_SOURCE=2
+
+CFLAGS   = $(GOPTI) $(GWARN) $(GDEBG)
+LDFLAGS  = -L/usr/lib32
+LDFLAGS += $(M32BIT)
 
 ifeq ($(OS),Windows_NT)
       detected_OS := Windows
@@ -56,7 +80,7 @@ ifeq ($(detected_OS),Darwin)
 endif
 endif
 
-#CC= gcc
+CC= gcc
 
 OBJS= main.o ops.o globals.o exp.o symbols.o \
       mne6303.o mne6502.o mne65c02.o mne68705.o mne6811.o mnef8.o mne68908.o

--- a/src/asm.h
+++ b/src/asm.h
@@ -46,11 +46,11 @@ typedef enum
 /* for -E option [phf] */
 typedef enum
 {
-  ERRORFORMAT_DEFAULT,
-  ERRORFORMAT_WOE = ERRORFORMAT_DEFAULT,
-  ERRORFORMAT_DILLON,
-  ERRORFORMAT_GNU,
-  ERRORFORMAT_MAX
+    ERRORFORMAT_DEFAULT,
+    ERRORFORMAT_WOE = ERRORFORMAT_DEFAULT,
+    ERRORFORMAT_DILLON,
+    ERRORFORMAT_GNU,
+    ERRORFORMAT_MAX
 } errorformat_t;
 
 #define DAD
@@ -123,46 +123,37 @@ enum ASM_ERROR_EQUATES
 
 typedef struct ERRORSTRUCT
 {
-    int nErrorType;                             /* ASM_ERROR_EQUATES value */
-    bool bFatal;                                /* 0 = OK, non-zero = cannot continue compilation */
+    int         nErrorType;                     /* ASM_ERROR_EQUATES value */
+    bool        bFatal;                         /* 0 = OK, non-zero = cannot continue compilation */
     const char *sDescription;                   /* Error message */
 
-    } ERROR_DEFINITION;
+} ERROR_DEFINITION;
 
 
-    enum REASON_CODES
-    {
-        REASON_MNEMONIC_NOT_RESOLVED = 1 << 0,
-        REASON_OBSCURE = 1 << 1,                        /* fix this! */
-        REASON_DC_NOT_RESOVED = 1 << 2,
-        REASON_DV_NOT_RESOLVED_PROBABLY = 1 << 3,
-        REASON_DV_NOT_RESOLVED_COULD = 1 << 4,
-        REASON_DS_NOT_RESOLVED = 1 << 5,
-        REASON_ALIGN_NOT_RESOLVED = 1 << 6,
-        REASON_ALIGN_RELOCATABLE_ORIGIN_NOT_KNOWN = 1 << 7,
-        REASON_ALIGN_NORMAL_ORIGIN_NOT_KNOWN = 1 << 8,
-        REASON_EQU_NOT_RESOLVED = 1 << 9,
-        REASON_EQU_VALUE_MISMATCH = 1 << 10,
-        REASON_IF_NOT_RESOLVED = 1 << 11,
-        REASON_REPEAT_NOT_RESOLVED = 1 << 12,
-        REASON_FORWARD_REFERENCE = 1 << 13,
-        REASON_PHASE_ERROR = 1 << 14,
-        REASON_BRANCH_OUT_OF_RANGE = 1 << 15,
-        REASON_INCLUDE_FAILED = 1 << 16,
-        REASON_INCBIN_NOT_RESOLVED = 1 << 17
-    };
+enum REASON_CODES
+{
+    REASON_MNEMONIC_NOT_RESOLVED = 1 << 0,
+    REASON_OBSCURE = 1 << 1,                        /* fix this! */
+    REASON_DC_NOT_RESOVED = 1 << 2,
+    REASON_DV_NOT_RESOLVED_PROBABLY = 1 << 3,
+    REASON_DV_NOT_RESOLVED_COULD = 1 << 4,
+    REASON_DS_NOT_RESOLVED = 1 << 5,
+    REASON_ALIGN_NOT_RESOLVED = 1 << 6,
+    REASON_ALIGN_RELOCATABLE_ORIGIN_NOT_KNOWN = 1 << 7,
+    REASON_ALIGN_NORMAL_ORIGIN_NOT_KNOWN = 1 << 8,
+    REASON_EQU_NOT_RESOLVED = 1 << 9,
+    REASON_EQU_VALUE_MISMATCH = 1 << 10,
+    REASON_IF_NOT_RESOLVED = 1 << 11,
+    REASON_REPEAT_NOT_RESOLVED = 1 << 12,
+    REASON_FORWARD_REFERENCE = 1 << 13,
+    REASON_PHASE_ERROR = 1 << 14,
+    REASON_BRANCH_OUT_OF_RANGE = 1 << 15,
+    REASON_INCLUDE_FAILED = 1 << 16,
+    REASON_INCBIN_NOT_RESOLVED = 1 << 17
+};
 
 
 #endif
-
-#define MNEMONIC    struct _MNE
-#define MACRO       struct _MACRO
-#define INCFILE     struct _INCFILE
-#define REPLOOP     struct _REPLOOP
-#define IFSTACK     struct _IFSTACK
-#define SEGMENT     struct _SEGMENT
-#define SYMBOL      struct _SYMBOL
-#define STRLIST     struct _STRLIST
 
 #define DEFORGFILL  255
 #define N_HASH_BITS 12          // 10 was in original implementation
@@ -172,45 +163,45 @@ typedef struct ERRORSTRUCT
 #define MHASHAND    (MHASHSIZE -1)
 #define ALLOCSIZE   16384
 #define MAXMACLEVEL 32
-#define TAB        9
+#define TAB         9
 
     /* 
      * See the file globals.c for what these correspond to (Cvt[] and Opsize[])
      */
-    enum ADDRESS_MODES {
-        AM_IMP,                 /*    1 - implied         */
-        AM_IMM8,                /*    2 - immediate 8  bits   */
-        AM_IMM16,               /*    3 - immediate 16 bits   */
-        AM_BYTEADR,             /*    4 - address 8 bits        */
-        AM_BYTEADRX,            /*    5 - index x + 8 bit offset     */
-        AM_BYTEADRY,            /*    6 - index y + 8 bit offset     */
-        AM_WORDADR,             /*    7 - extended addr        */
-        AM_WORDADRX,            /*    8 - index x + 16 bit offset       */
-        AM_WORDADRY,            /*    9 - index y + 16 bit offset      */
-        AM_REL,                 /*    10- relative 8 bits   */
-        AM_BYTEREL,             /*    11- 8 bits relative    */
-        AM_INDBYTEX,            /*    12- indirect x     */
-        AM_INDBYTEY,            /*    13- indirect y     */
-        AM_INDWORD,             /*    14- indirect immediate    */
-        AM_INDWORDX,            /*    15- indirect 16 bits x-indexed  */
-        AM_INDBYTE,             /*    16- indirect 8 bits        */
-        AM_0X,                  /*    17- index x 0 bits        */
-        AM_0Y,                  /*    18- index y 0 bits        */
-        AM_BITMOD,              /*    19- spec. bit modifcation     */
-        AM_BITBRAMOD,           /*    20- spec. bit-test rel. branch    */
-        AM_BYTEADR_SP,          /*    21- index SP +8 bits     */
-        AM_WORDADR_SP,          /*    22- index SP +16 bits   */
+enum ADDRESS_MODES {
+    AM_IMP,                 /*    1 - implied         */
+    AM_IMM8,                /*    2 - immediate 8  bits   */
+    AM_IMM16,               /*    3 - immediate 16 bits   */
+    AM_BYTEADR,             /*    4 - address 8 bits        */
+    AM_BYTEADRX,            /*    5 - index x + 8 bit offset     */
+    AM_BYTEADRY,            /*    6 - index y + 8 bit offset     */
+    AM_WORDADR,             /*    7 - extended addr        */
+    AM_WORDADRX,            /*    8 - index x + 16 bit offset       */
+    AM_WORDADRY,            /*    9 - index y + 16 bit offset      */
+    AM_REL,                 /*    10- relative 8 bits   */
+    AM_BYTEREL,             /*    11- 8 bits relative    */
+    AM_INDBYTEX,            /*    12- indirect x     */
+    AM_INDBYTEY,            /*    13- indirect y     */
+    AM_INDWORD,             /*    14- indirect immediate    */
+    AM_INDWORDX,            /*    15- indirect 16 bits x-indexed  */
+    AM_INDBYTE,             /*    16- indirect 8 bits        */
+    AM_0X,                  /*    17- index x 0 bits        */
+    AM_0Y,                  /*    18- index y 0 bits        */
+    AM_BITMOD,              /*    19- spec. bit modifcation     */
+    AM_BITBRAMOD,           /*    20- spec. bit-test rel. branch    */
+    AM_BYTEADR_SP,          /*    21- index SP +8 bits     */
+    AM_WORDADR_SP,          /*    22- index SP +16 bits   */
 
 
-        AM_SYMBOL,
-        AM_EXPLIST,
-        AM_LONG,
-        AM_BSS,
+    AM_SYMBOL,
+    AM_EXPLIST,
+    AM_LONG,
+    AM_BSS,
 
-        AM_OTHER_ENDIAN,                /* force little endian to DC on big endian machines and the other way round */
+    AM_OTHER_ENDIAN,                /* force little endian to DC on big endian machines and the other way round */
 
-        NUMOC
-    };
+    NUMOC
+};
 
 #define AF_IMP                  ( 1L << AM_IMP )
 #define AF_IMM8                 ( 1L << AM_IMM8 )
@@ -240,9 +231,10 @@ typedef struct ERRORSTRUCT
 
 
 
-STRLIST {
-    STRLIST *next;
-    char    buf[4];
+typedef struct _STRLIST  STRLIST;
+struct _STRLIST {
+    STRLIST    *next;
+    char       buf[4];
 };
 
 #define STRLISTSIZE    sizeof(STRLIST *)
@@ -255,41 +247,44 @@ STRLIST {
 #define MF_IMOD                 0x40    /*  instruction byte mod.    */
 #define MF_ENDM                 0x80    /*  is v_endm            */
 
-MNEMONIC {
-    MNEMONIC     *next;        /*    hash        */
-    void    (*vect)(char *, MNEMONIC *);    /*  dispatch        */
-    const char    *name;        /*    actual name    */
-    unsigned char   flags;        /*    special flags    */
+typedef struct _MNEMONIC MNEMONIC;
+struct _MNEMONIC {
+    MNEMONIC        *next;          /*    hash        */
+    void            (*vect)(char *, MNEMONIC *);    /*  dispatch        */
+    const char      *name;          /*    actual name    */
+    unsigned char   flags;          /*    special flags    */
     unsigned long   okmask;
-    unsigned int opcode[NUMOC];  /*    hex codes, byte or word (>xFF) opcodes    */
+    unsigned int    opcode[NUMOC];  /*    hex codes, byte or word (>xFF) opcodes    */
 };
 
 /* MNEMONIC with all fields 0, used as end-of-table marker. */
 #define MNEMONIC_NULL {NULL, NULL, NULL, 0, 0, {0,}}
 
-MACRO {
-    MACRO   *next;
-    void    (*vect)(char *, MACRO *);
-    char    *name;
+typedef struct _MACRO   MACRO;
+struct _MACRO {
+    MACRO           *next;
+    void            (*vect)(char *, MACRO *);
+    char            *name;
     unsigned char   flags;
-    STRLIST *strlist;
-    int defpass;
+    STRLIST         *strlist;
+    int             defpass;
 };
 
 #define INF_MACRO   0x01
 #define INF_NOLIST  0x02
 
-INCFILE {
-    INCFILE *next;  /*      previously pushed context */
-    char    *name;  /*      file name            */
-    FILE    *fi;    /*      file handle            */
+typedef struct _INCFILE     INCFILE;
+struct _INCFILE {
+    INCFILE         *next;  /*      previously pushed context */
+    char            *name;  /*      file name            */
+    FILE            *fi;    /*      file handle            */
     unsigned long   lineno; /*      line number in file        */
     unsigned char   flags;  /*      flags (macro)         */
 
     /*    Only if Macro    */
 
-    STRLIST *args;    /*  arguments to macro        */
-    STRLIST *strlist;    /*  current string list     */
+    STRLIST         *args;      /*  arguments to macro        */
+    STRLIST         *strlist;   /*  current string list     */
     unsigned long   saveidx;    /*  save localindex        */
     unsigned long   savedolidx; /*  save localdollarindex   */
 
@@ -297,34 +292,37 @@ INCFILE {
 
 #define RPF_UNKNOWN 0x01    /*      value unknown     */
 
-REPLOOP {
-    REPLOOP *next;  /*      previously pushed context */
+typedef struct _REPLOOP  REPLOOP;
+struct _REPLOOP {
+    REPLOOP         *next;  /*      previously pushed context */
     unsigned long   count;  /*      repeat count            */
     unsigned long   seek;   /*      seek to top of repeat     */
     unsigned long   lineno; /*      line number of line before  */
-    INCFILE *file;  /*      which include file are we in*/
+    INCFILE         *file;  /*      which include file are we in*/
     unsigned char   flags;
 };
 
 #define IFF_UNKNOWN 0x01    /*      value unknown        */
 #define IFF_BASE    0x04
 
-IFSTACK {
-    IFSTACK *next;  /*      previous IF            */
-    INCFILE *file;  /*      which include file are we in*/
+typedef struct _IFSTACK  IFSTACK;
+struct _IFSTACK {
+    IFSTACK         *next;  /*      previous IF            */
+    INCFILE         *file;  /*      which include file are we in*/
     unsigned char   flags;
     unsigned char   xtrue;   /*      1 if true, 0 if false     */
     unsigned char   acctrue;/*      accumulatively true (not incl this one) */
 };
 
 #define SF_UNKNOWN  0x01    /*      ORG unknown            */
-#define SF_REF        0x04    /*      ORG referenced        */
-#define SF_BSS        0x10    /*      uninitialized area (U flag)    */
+#define SF_REF      0x04    /*      ORG referenced        */
+#define SF_BSS      0x10    /*      uninitialized area (U flag)    */
 #define SF_RORG     0x20    /*      relocatable origin active    */
 
-SEGMENT {
-    SEGMENT *next;  /*      next segment in segment list    */
-    char    *name;  /*      name of segment        */
+typedef struct _SEGMENT  SEGMENT;
+struct _SEGMENT {
+    SEGMENT         *next;  /*      next segment in segment list    */
+    char            *name;  /*      name of segment        */
     unsigned char   flags;  /*      for ORG            */
     unsigned char   rflags; /*      for RORG            */
     unsigned long   org;    /*      current org            */
@@ -342,35 +340,36 @@ SEGMENT {
 #define SYM_MACRO   0x20    /*      symbol is a macro    */
 #define SYM_MASREF  0x40    /*      master reference    */
 
-SYMBOL {
-    SYMBOL  *next;    /*  next symbol in hash list        */
-    char    *name;    /*  symbol name or string if expr.  */
-    char    *string;    /*  if symbol is actually a string  */
+typedef struct _SYMBOL  SYMBOL;
+struct _SYMBOL {
+    SYMBOL          *next;    /*  next symbol in hash list        */
+    char            *name;    /*  symbol name or string if expr.  */
+    char            *string;  /*  if symbol is actually a string  */
     unsigned char   flags;    /*  flags                */
-    unsigned char   addrmode;    /*  addressing mode (expressions)   */
-    long value; /* current value, never EVER change this to unsigned! */
-    unsigned int namelen;    /*  name length             */
-    long order;
+    unsigned char   addrmode; /*  addressing mode (expressions)   */
+    long            value;    /* current value, never EVER change this to unsigned! */
+    unsigned int    namelen;  /*  name length             */
+    long            order;
 };
 
-extern SYMBOL    *SHash[];
-extern MNEMONIC    *MHash[];
+extern SYMBOL     *SHash[];
+extern MNEMONIC   *MHash[];
 extern INCFILE    *pIncfile;
 extern REPLOOP    *Reploop;
 extern SEGMENT    *Seglist;
 extern IFSTACK    *Ifstack;
 
 extern SEGMENT    *Csegment;  /*      current segment */
-extern char    *Av[];
-extern char    Avbuf[];
+extern char       *Av[];
+extern char       Avbuf[];
 /*extern unsigned int Adrbytes[];*/
 extern unsigned int Cvt[];
-extern MNEMONIC    Ops[];
+extern MNEMONIC     Ops[];
 extern unsigned int    Opsize[];
-extern int    Mnext;          /*    mnemonic extension    */
+extern int             Mnext;          /*    mnemonic extension    */
 extern unsigned int    Mlevel;
 
-extern bool bTrace;
+extern bool     bTrace;
 extern bool     Xdebug;
 extern bool     bStrictMode;
 extern unsigned char    MsbOrder;
@@ -385,20 +384,20 @@ extern int Redo_eval;
 extern unsigned long    Redo_if;
 extern unsigned long    Localindex, Lastlocalindex;
 extern unsigned long    Localdollarindex, Lastlocaldollarindex;
-extern int   F_format;
-extern sortmode_t F_sortmode; /* -T option [phf] */
+extern int           F_format;
+extern sortmode_t    F_sortmode;    /* -T option [phf] */
 extern errorformat_t F_errorformat; /* -E option [phf] */
-extern unsigned char    F_verbose;
+extern unsigned char F_verbose;
 extern const char    *F_outfile;
-extern char    *F_listfile;
-extern char    *F_symfile;
-extern FILE    *FI_listfile;
-extern FILE    *FI_temp;
-extern unsigned char    Fisclear;
-extern unsigned long    Plab, Pflags;
-extern char    Inclevel;
-extern char    ListMode;
-extern unsigned long    Processor;
+extern char          *F_listfile;
+extern char          *F_symfile;
+extern FILE          *FI_listfile;
+extern FILE          *FI_temp;
+extern unsigned char Fisclear;
+extern unsigned long Plab, Pflags;
+extern char          Inclevel;
+extern char          ListMode;
+extern unsigned long Processor;
 
 /*extern unsigned int _fmode;*/
 extern unsigned long  SymbolCount;
@@ -410,7 +409,7 @@ extern int nMacroClosings;
 /* main.c */
 /*extern unsigned char Listing;*/
 void    findext(char *str);
-int    asmerr(int err, bool bAbort, const char *sText);
+int     asmerr(int err, bool bAbort, const char *sText);
 char   *sftos(long val, int flags);
 void    rmnode(void **base, int bytes);
 void    addhashtable(MNEMONIC *mne);
@@ -419,7 +418,7 @@ char   *permalloc(int bytes);
 char   *zmalloc(int bytes);
 char   *ckmalloc(int bytes);
 char   *strlower(char *str);
-void addmsg(char *message);
+void    addmsg(char *message);
 
 /* symbols.c */
 void    setspecial(int value, int flags);
@@ -427,7 +426,7 @@ SYMBOL *allocsymbol(void);
 SYMBOL *findsymbol(const char *str, int len);
 SYMBOL *CreateSymbol( const char *str, int len, bool addToOrder );
 void    FreeSymbolList(SYMBOL *sym);
-void    programlabel();
+void    programlabel(void);
 
 /* ops.c */
 extern    unsigned char Gen[];

--- a/src/exp.c
+++ b/src/exp.c
@@ -59,40 +59,40 @@ static void stackarg(long val, int flags, const char *ptr1);
 
 void doop(opfunc_t, int pri);
 void evaltop(void);
-void	op_mult(long v1, long v2, int f1, int f2),
-op_div(long v1, long v2, int f1, int f2),
-op_mod(long v1, long v2, int f1, int f2),
-op_add(long v1, long v2, int f1, int f2),
-op_sub(long v1, long v2, int f1, int f2),
-op_shiftleft(long v1, long v2, int f1, int f2),
-op_shiftright(long v1, long v2, int f1, int f2),
-op_greater(long v1, long v2, int f1, int f2),
-op_greatereq(long v1, long v2, int f1, int f2),
-op_smaller(long v1, long v2, int f1, int f2),
-op_smallereq(long v1, long v2, int f1, int f2),
-op_eqeq(long v1, long v2, int f1, int f2),
-op_noteq(long v1, long v2, int f1, int f2),
-op_andand(long v1, long v2, int f1, int f2),
-op_oror(long v1, long v2, int f1, int f2),
-op_xor(long v1, long v2, int f1, int f2),
-op_and(long v1, long v2, int f1, int f2),
-op_or(long v1, long v2, int f1, int f2),
-op_question(long v1, long v2, int f1, int f2);
+void	op_mult(      long v1, long v2, int f1, int f2),
+	op_div(       long v1, long v2, int f1, int f2),
+	op_mod(       long v1, long v2, int f1, int f2),
+	op_add(       long v1, long v2, int f1, int f2),
+	op_sub(       long v1, long v2, int f1, int f2),
+	op_shiftleft( long v1, long v2, int f1, int f2),
+	op_shiftright(long v1, long v2, int f1, int f2),
+	op_greater(   long v1, long v2, int f1, int f2),
+	op_greatereq( long v1, long v2, int f1, int f2),
+	op_smaller(   long v1, long v2, int f1, int f2),
+	op_smallereq( long v1, long v2, int f1, int f2),
+	op_eqeq(      long v1, long v2, int f1, int f2),
+	op_noteq(     long v1, long v2, int f1, int f2),
+	op_andand(    long v1, long v2, int f1, int f2),
+	op_oror(      long v1, long v2, int f1, int f2),
+	op_xor(       long v1, long v2, int f1, int f2),
+	op_and(       long v1, long v2, int f1, int f2),
+	op_or(        long v1, long v2, int f1, int f2),
+	op_question(  long v1, long v2, int f1, int f2);
 
 void	op_takelsb(long v1, int f1),
-op_takemsb(long v1, int f1),
-op_negate(long v1, int f1),
-op_invert(long v1, int f1),
-op_not(long v1, int f1);
+	op_takemsb(long v1, int f1),
+	op_negate( long v1, int f1),
+	op_invert( long v1, int f1),
+	op_not(    long v1, int f1);
 
 
 const char *pushsymbol(const char *str);
-const char *pushstr(const char *str);
-const char *pushbin(const char *str);
-const char *pushoct(const char *str);
-const char *pushdec(const char *str);
-const char *pushhex(const char *str);
-const char *pushchar(const char *str);
+const char *pushstr(   const char *str);
+const char *pushbin(   const char *str);
+const char *pushoct(   const char *str);
+const char *pushdec(   const char *str);
+const char *pushhex(   const char *str);
+const char *pushchar(  const char *str);
 
 int IsAlphaNum( int c );
 
@@ -562,7 +562,7 @@ SYMBOL *eval(const char *str, int wantmode)
             {
                 if (str[1] == 'x') {                   // allow also '0xAA' notation for '$AA'
                     ++str;
-                    str = (char *)pushhex(str+1);
+                    str = (const char *)pushhex(str+1);
                 } else {
                 str = pushoct(str);
                 }

--- a/src/ftohex.c
+++ b/src/ftohex.c
@@ -43,8 +43,7 @@ void convert(int format, FILE *in, FILE *out);
 unsigned int getwlh(FILE *in);
 void puth(unsigned char c, FILE *out);
 
-int
-main(int ac, char **av)
+int main(int ac, char **av)
 {
     int format;
     FILE *infile;
@@ -72,8 +71,7 @@ main(int ac, char **av)
     return 0;
 }
 
-void
-exiterr(const char *str)
+void exiterr(const char *str)
 {
     fputs(str, stderr);
     fputs("\n", stderr);
@@ -94,11 +92,9 @@ exiterr(const char *str)
  *			cc=invert of checksum all codes
  */
 
-void
-convert(int format, FILE *in, FILE *out)
+void convert(int format, FILE *in, FILE *out)
 {
     unsigned int org = 0;
-    unsigned int idx;
     long len;
     unsigned char buf[256];
 
@@ -116,9 +112,17 @@ convert(int format, FILE *in, FILE *out)
 	while (len > 0) {
 	    register unsigned char chk;
 	    register unsigned int i;
+	    size_t  idx;
+            size_t  items;
 
 	    idx = (len > PERLINE) ? PERLINE : len;
-	    fread(buf, idx, 1, in);
+	    items = fread(buf, idx, 1, in);	/* size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream); */
+	    if( 1 != items ) {			/* fread() return number of items */
+		char ebuf[256];
+		snprintf(ebuf, sizeof(ebuf),
+			" fread(buf, %u, 1, in) return only %u", idx, items);
+		exiterr(ebuf);
+	    }
 	    putc(':', out);
 	    puth(idx, out);
 	    puth(org >> 8, out);
@@ -157,8 +161,7 @@ unsigned int getwlh(FILE *in)
     return result;
 }
 
-void
-puth(unsigned char c, FILE *out)
+void puth(unsigned char c, FILE *out)
 {
     static char dig[] = { "0123456789ABCDEF" };
     putc(dig[c>>4], out);

--- a/src/main.c
+++ b/src/main.c
@@ -1848,7 +1848,7 @@ void passbuffer_output(int mbindex)
     printf("%s\n",passbuffer[mbindex]); // ...do we really still need to put this through stdout, instead stderr?
 }
 
-void passbuffer_cleanup()
+void passbuffer_cleanup(void)
 {
     int t;
     for(t=0;t<2;t++)

--- a/src/mnef8.c
+++ b/src/mnef8.c
@@ -369,7 +369,7 @@ static void v_lisu_lisl(char *str, MNEMONIC *mne) {
  */
 static void v_sreg_op(char *str, MNEMONIC *mne) {
 
-    unsigned char reg;
+    unsigned char reg = 0;
 
     programlabel();
     parse_scratchpad_register(str, &reg);

--- a/src/ops.c
+++ b/src/ops.c
@@ -220,45 +220,47 @@ void v_mnemonic(char *str, MNEMONIC *mne)
         addrmode = Mnext;
 
         //FIX: OPCODE.FORCE needs to be adjusted for x,y,sp indexing...
-        switch(sym->addrmode) {
-        	case AM_INDBYTEX:
-        	case AM_INDBYTEY:
-        		// there is only INDWORD to force indirect addressing mode but not with X or Y
-        		// this must be an error
-                asmerr( ERROR_ILLEGAL_FORCED_ADDRESSING_MODE, false, mne->name );
-                FreeSymbolList(symbase);
+	switch(sym->addrmode) {
+	    case AM_INDBYTEX:
+	    case AM_INDBYTEY:
+		// there is only INDWORD to force indirect addressing mode but not with X or Y
+		// this must be an error
+		asmerr( ERROR_ILLEGAL_FORCED_ADDRESSING_MODE, false, mne->name );
+		FreeSymbolList(symbase);
 
-                //FIX: Cause assembly to fail when an invalid mode is used for an opcode...
-                ++Redo;
-                Redo_why |= REASON_MNEMONIC_NOT_RESOLVED;
-                return;
+		//FIX: Cause assembly to fail when an invalid mode is used for an opcode...
+		++Redo;
+		Redo_why |= REASON_MNEMONIC_NOT_RESOLVED;
+		return;
 
-        	case AM_BYTEADR_SP:
-        		addrmode = AM_BYTEADR_SP;
-                if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADR_SP))
-                	addrmode = AM_WORDADR_SP;
-        		break;
+	    case AM_BYTEADR_SP:
+		addrmode = AM_BYTEADR_SP;
+		if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADR_SP))
+		    addrmode = AM_WORDADR_SP;
+		break;
 
-        	case AM_0Y:
-        		addrmode = AM_0Y;
+	    case AM_0Y:
+		addrmode = AM_0Y;
 
-            	if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADRY))
-            		addrmode = AM_WORDADRY;
+		if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADRY)){
+		    addrmode = AM_WORDADRY;
+		}
+		if ((Mnext == AM_BYTEADR) || (Mnext == AM_BYTEADRY)){
+		    addrmode = AM_BYTEADRY;
+		}
+		break;
 
-            	if ((Mnext == AM_BYTEADR) || (Mnext == AM_BYTEADRY))
-            		addrmode = AM_BYTEADRY;
-        		break;
+	    case AM_0X:
+		addrmode = AM_0X;
 
-        	case AM_0X:
-        		addrmode = AM_0X;
-
-                if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADRX))
-                	addrmode = AM_WORDADRX;
-
-                if ((Mnext == AM_BYTEADR) || (Mnext == AM_BYTEADRX))
-                	addrmode = AM_BYTEADRX;
-        		break;
-        }
+		if ((Mnext == AM_WORDADR) || (Mnext == AM_WORDADRX)){
+		    addrmode = AM_WORDADRX;
+		}
+		if ((Mnext == AM_BYTEADR) || (Mnext == AM_BYTEADRX)){
+		    addrmode = AM_BYTEADRX;
+		}
+		break;
+	}
 
 
         if (badcode(mne,addrmode))

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -148,7 +148,7 @@ static unsigned int hash1(const char *str, int len)
 *  Label Support Routines
 */
 
-void programlabel()
+void programlabel(void)
 {
     int len;
     SYMBOL *sym;


### PR DESCRIPTION
asm.h: remove MACROS(MNEMONIC,MACRO,INCFILE,REPLOOP,IFSTACK,SEGMENT,SYMBOL,STRLIST) use typedef
src/Makefile: enable compiler switches to hunt errors/warnings
src/exp.c: remove: warning: cast discards ‘const’ qualifier from pointer target 
src/symbols.c: remove: warning: old-style function definition
src/ops.c: remove: this ‘if’ clause does not guard...
src/main.c: remove: warning: old-style function definition
src/ftohex.c: remove: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’
src/mnef8.c: remove: warning: ‘reg’ may be used uninitialized in this function
There are more warnings which can be enabled in Makefile but not so easy to fix
br beered