### PR TITLE
fixed typo in macro.h

### DIFF
--- a/machines/atari2600/macro.h
+++ b/machines/atari2600/macro.h
@@ -93,7 +93,7 @@ VERSION_MACRO         = 110
 .VSLP1          sta WSYNC           ; 1st '0' bit resets Vsync, 2nd '0' bit exit loop
                 sta VSYNC
                 lsr
-                bne .VSLP1          ; branch until VYSNC has been reset
+                bne .VSLP1          ; branch until VSYNC has been reset
              ENDM
 
 ;-------------------------------------------------------------------------------


### PR DESCRIPTION
Noticed VYNSC in macro.h in a .lst file dump, fixed the typo in macro.h